### PR TITLE
Add ability to output logs to one file per scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,16 @@ You can get a logger by calling the following once Herodotus is installed:
 logger = DVLA::Herodotus.logger
 ```
 
-You can also provide the path to an output file, which will be logged to simultaneously with standard console logger
+You can also log out to a file. If you want all the logs in a single file, provide a string of the path to that output file and it will be logged to simultaneously with standard console logger
 
 ```ruby
 logger = DVLA::Herodotus.logger(output_path: 'logs.txt')
+```
+
+Alternatively, if you want each scenario to log out to a separate file based on the scenario name, pass in a lambda that returns a string that attempts to interpolate `@scenario`.
+
+```ruby
+logger = DVLA::Herodotus.logger(output_path: -> { "#{@scenario}_log.txt" })
 ```
 
 This is a standard Ruby logger, so anything that would work on a logger acquired the traditional way will also work here, however it is formatted such that all logs will be output in the following format:

--- a/lib/dvla/herodotus.rb
+++ b/lib/dvla/herodotus.rb
@@ -1,6 +1,7 @@
 require 'logger'
 require_relative 'herodotus/herodotus_logger'
 require_relative 'herodotus/multi_writer'
+require_relative 'herodotus/proc_writer'
 require_relative 'herodotus/string'
 
 module DVLA
@@ -29,11 +30,17 @@ module DVLA
 
     private_class_method def self.create_logger(output_path)
       if output_path
-        output_file = File.open(output_path, 'a+')
-        HerodotusLogger.new(MultiWriter.new(output_file, $stdout))
-      else
-        HerodotusLogger.new($stdout)
+        if output_path.is_a? String
+          output_file = File.open(output_path, 'a')
+          return HerodotusLogger.new(MultiWriter.new(output_file, $stdout))
+        elsif output_path.is_a? Proc
+          proc_writer = ProcWriter.new(output_path)
+          return HerodotusLogger.new(MultiWriter.new(proc_writer, $stdout))
+        else
+          raise ArgumentError.new "Unexpected output_path provided. Expecting either a string or a proc"
+        end
       end
+      HerodotusLogger.new($stdout)
     end
   end
 end

--- a/lib/dvla/herodotus/multi_writer.rb
+++ b/lib/dvla/herodotus/multi_writer.rb
@@ -1,6 +1,8 @@
 module DVLA
   module Herodotus
     class MultiWriter
+      attr_reader :targets
+
       def initialize(*targets)
         @targets = *targets
       end

--- a/lib/dvla/herodotus/proc_writer.rb
+++ b/lib/dvla/herodotus/proc_writer.rb
@@ -1,0 +1,20 @@
+module DVLA
+  module Herodotus
+    class ProcWriter
+      attr_accessor :scenario
+      def initialize(proc)
+        @proc = proc
+      end
+
+      def write(*args)
+        output_file = File.open(self.instance_exec(&@proc), 'a')
+        output_file.write(args[0])
+        output_file.close
+      end
+
+      def close
+        # Nothing to close but we want to maintain consistency with other ways Herodotus can output
+      end
+    end
+  end
+end

--- a/lib/dvla/herodotus/version.rb
+++ b/lib/dvla/herodotus/version.rb
@@ -1,5 +1,5 @@
 module DVLA
   module Herodotus
-    VERSION = '1.1.0'.freeze
+    VERSION = '1.2.0'.freeze
   end
 end

--- a/spec/dvla/herodotus/proc_writer_spec.rb
+++ b/spec/dvla/herodotus/proc_writer_spec.rb
@@ -1,0 +1,35 @@
+require 'dvla/herodotus'
+
+RSpec.describe DVLA::Herodotus::ProcWriter do
+  it 'writes to a file with the name the provided proc returns' do
+    log_message = 'Example log message'
+
+    expected_filename = 'test_log_file.txt'
+    filename_proc = Proc.new { expected_filename }
+    proc_writer = DVLA::Herodotus::ProcWriter.new(filename_proc)
+
+    file_double = instance_double(File)
+    expect(file_double).to receive(:write).with(log_message)
+    allow(file_double).to receive(:close)
+    allow(File).to receive(:open).and_call_original
+    allow(File).to receive(:open).with(expected_filename, 'a').and_return(file_double)
+
+    proc_writer.write(log_message)
+  end
+
+  it 'correctly interpolates the file name from the provided proc to write the log' do
+    log_message = 'Example log message'
+
+    expected_filename = 'expected_filename.txt'
+    filename_proc = Proc.new { "#{@scenario}.txt" }
+    proc_writer = DVLA::Herodotus::ProcWriter.new(filename_proc)
+    proc_writer.scenario = 'expected_filename'
+
+    file_double = instance_double(File)
+    allow(File).to receive(:open).with(expected_filename, 'a').and_return(file_double)
+    expect(file_double).to receive(:write).with(log_message)
+    allow(file_double).to receive(:close)
+
+    proc_writer.write(log_message)
+  end
+end

--- a/spec/dvla/herodotus_spec.rb
+++ b/spec/dvla/herodotus_spec.rb
@@ -89,22 +89,47 @@ RSpec.describe DVLA::Herodotus do
                                         .to_stdout_from_any_process
   end
 
-  it 'returns a logger that outputs to both the standard output and a file if an output_path is passed in' do
+  it 'returns a logger that outputs to both the standard output and a file if a string is passed in as an output_path' do
     allow(Time).to receive(:now)
                      .and_return(Time.new(2022))
     allow(SecureRandom).to receive(:uuid)
                              .and_return('123e4567-e89b-12d3-a456-426614174000')
-    allow(Process).to receive(:pid)
-                        .and_return(1234)
 
     file_double = instance_double(File)
     expect(file_double).to receive(:write).with("[2022-01-01 00:00:00 123e4567] INFO -- : test\n")
     allow(File).to receive(:open).and_call_original
-    allow(File).to receive(:open).with('example_file.txt', 'a+').and_return(file_double)
+    allow(File).to receive(:open).with('example_file.txt', 'a').and_return(file_double)
 
     logger = DVLA::Herodotus.logger(output_path: 'example_file.txt')
 
     expect { logger.info('test') }.to output("[2022-01-01 00:00:00 123e4567] INFO -- : test\n")
                                         .to_stdout_from_any_process
+  end
+
+  it 'returns a logger that outputs to both the standard output and scenario-based files if a proc is passed in as an output_path' do
+    allow(Time).to receive(:now)
+                     .and_return(Time.new(2022))
+    allow(SecureRandom).to receive(:uuid)
+                             .and_return('123e4567-e89b-12d3-a456-426614174000')
+
+    example_scenario_name = 'example_scenario'
+
+    file_double = instance_double(File)
+    expect(file_double).to receive(:write).with("[2022-01-01 00:00:00 123e4567] INFO -- : test\n")
+    allow(file_double).to receive(:close)
+    allow(File).to receive(:open).and_call_original
+    allow(File).to receive(:open).with("#{example_scenario_name}_log.txt", 'a').and_return(file_double)
+
+    logger = DVLA::Herodotus.logger(output_path: Proc.new { "#{@scenario}_log.txt" })
+
+    logger.new_scenario(example_scenario_name)
+
+    expect { logger.info('test') }.to output("[2022-01-01 00:00:00 123e4567] INFO -- : test\n")
+                                        .to_stdout_from_any_process
+  end
+
+  it 'raises an error when an unexpected type is passed in as an output_path' do
+    unexpected_int = 123
+    expect { DVLA::Herodotus.logger(output_path: unexpected_int) }.to raise_error(ArgumentError, 'Unexpected output_path provided. Expecting either a string or a proc')
   end
 end


### PR DESCRIPTION
# What

- Allow the consumer to pass a lambda in as an output path for Herodotus

# Why

- Enables the logs to be write out to different files, depending on what scenario generated them