### PR TITLE
Colourise prefix via config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.3.0] - 2025-10-05
+- Config block can now accept prefix colour options. Can be applied to the whole prefix or configure individual components.
+
 ## [2.2.1] - 2025-09-15
 - Fixed issue with ANSI exit codes breaking on string interpolation
 - Added strip_colour method to String which we now call when sending logs to file

--- a/README.md
+++ b/README.md
@@ -63,50 +63,24 @@ This would result in logs in the following format:
 `[SystemName CurrentDate CurrentTime CorrelationId PID] Level : -- Message`
 
 #### Prefix Colourisation
-You can colourise the log prefix in several ways:
+You can colourise different parts of the log prefix by providing a hash with an array of strings to style each component:
 
-**Apply colours to the entire prefix:**
-```ruby
-config = DVLA::Herodotus.config do |config|
-  config.prefix_colour = 'blue.bold'
-end
-logger = DVLA::Herodotus.logger('<system-name>', config: config)
-```
-
-**Use an array of colour methods:**
-
-```ruby
-config = DVLA::Herodotus.config do |config|
-  config.prefix_colour = %w[blue bold underline]
-end
-logger = DVLA::Herodotus.logger('<system-name>', config: config)
-```
-
-**Apply different colours to individual components:**
 ```ruby
 config = DVLA::Herodotus.config do |config|
   config.prefix_colour = {
-    system: 'blue.bold',
-    date: 'green',
-    time: 'yellow',
-    correlation: 'magenta',
-    pid: 'cyan',
-    level: 'red.bold',
-    separator: 'white'
+    system: %w[blue bold],
+    date: %w[green],
+    time: %w[yellow],
+    correlation: %w[magenta],
+    pid: %w[cyan],
+    level: %w[red bold],
+    separator: %w[white],
+    overall: %w[underline]
   }
 end
-logger = DVLA::Herodotus.logger('<system-name>', config: config)
 ```
-
-The hash keys correspond to different parts of the log prefix:
-- `system`: The system name
-- `date`: The date portion (YYYY-MM-DD)
-- `time`: The time portion (HH:MM:SS)
-- `correlation`: The correlation ID
-- `pid`: The process ID (when display_pid is enabled)
-- `level`: The log level (INFO, WARN, etc.)
-- `separator`: The "-- :" separator
-- `overall`: Applied to the entire prefix after individual components are coloured
+Each key is optional, and you can simply use the `overall` key to style the whole prefix.
+---
 
 ### Syncing logs
 
@@ -128,6 +102,7 @@ You can call `new_scenario` with the identifier just before each scenario to cre
 logger.new_scenario('Scenario Id')
 ```
 
+---
 ### Strings
 
 Also included is a series of additional methods on `String` that allow you to modify the colour and style of logs.
@@ -140,14 +115,14 @@ You can stack multiple method calls to add additional styling and use string int
 
 #### Available String Methods
 
-| Type | Examples |
-|------|----------|
-| Text Styles | **bold** <span style="opacity:0.6">dim</span> *italic* <u>underline</u> |
-| Colors | <span style="color:black">black</span> <span style="color:red">red</span> <span style="color:green">green</span> <span style="color:#B8860B">brown</span> <span style="color:#ffff00">yellow</span> <span style="color:blue">blue</span> <span style="color:magenta">magenta</span> <span style="color:cyan">cyan</span> <span style="color:grey">gray</span> <span style="color:white">white</span> |
-| Bright Colors | <span style="color:#ff5555">bright_red</span> <span style="color:#55ff55">bright_green</span> <span style="color:#5555ff">bright_blue</span> <span style="color:#ff55ff">bright_magenta</span> <span style="color:#55ffff">bright_cyan</span> |
-| Background Colors | <span style="background:black;color:white">bg_black</span> <span style="background:red;color:white">bg_red</span> <span style="background:green;color:white">bg_green</span> <span style="background:#B8860B;color:white">bg_brown</span> <span style="background:#ffff00;color:black">bg_yellow</span> <span style="background:blue;color:white">bg_blue</span> <span style="background:magenta;color:white">bg_magenta</span> <span style="background:cyan;color:black">bg_cyan</span> <span style="background:grey;color:white">bg_gray</span> <span style="background:white;color:black">bg_white</span> |
-| Bright Background Colors | <span style="background:#ff5555;color:white">bg_bright_red</span> <span style="background:#55ff55;color:black">bg_bright_green</span> <span style="background:#5555ff;color:white">bg_bright_blue</span> <span style="background:#ff55ff;color:white">bg_bright_magenta</span> <span style="background:#55ffff;color:black">bg_bright_cyan</span> |
-| Utility | strip_colour reverse_colour |
+| Type                      | Examples |
+|---------------------------|----------|
+| Text Styles               | **bold** <span style="opacity:0.6">dim</span> *italic* <u>underline</u> |
+| Colours                   | <span style="color:black">black</span> <span style="color:red">red</span> <span style="color:green">green</span> <span style="color:#B8860B">brown</span> <span style="color:#ffff00">yellow</span> <span style="color:blue">blue</span> <span style="color:magenta">magenta</span> <span style="color:cyan">cyan</span> <span style="color:grey">gray</span> <span style="color:white">white</span> |
+| Bright Colours            | <span style="color:#ff5555">bright_red</span> <span style="color:#55ff55">bright_green</span> <span style="color:#5555ff">bright_blue</span> <span style="color:#ff55ff">bright_magenta</span> <span style="color:#55ffff">bright_cyan</span> |
+| Background Colours        | <span style="background:black;color:white">bg_black</span> <span style="background:red;color:white">bg_red</span> <span style="background:green;color:white">bg_green</span> <span style="background:#B8860B;color:white">bg_brown</span> <span style="background:#ffff00;color:black">bg_yellow</span> <span style="background:blue;color:white">bg_blue</span> <span style="background:magenta;color:white">bg_magenta</span> <span style="background:cyan;color:black">bg_cyan</span> <span style="background:grey;color:white">bg_gray</span> <span style="background:white;color:black">bg_white</span> |
+| Bright Background Colours | <span style="background:#ff5555;color:white">bg_bright_red</span> <span style="background:#55ff55;color:black">bg_bright_green</span> <span style="background:#5555ff;color:white">bg_bright_blue</span> <span style="background:#ff55ff;color:white">bg_bright_magenta</span> <span style="background:#55ffff;color:black">bg_bright_cyan</span> |
+| Utility                   | strip_colour reverse_colour |
 
 #### To handle differences in spelling the following methods have been given aliases:
 | Alias         | Original       |
@@ -157,6 +132,8 @@ You can stack multiple method calls to add additional styling and use string int
 | grey          | gray           |
 | reverse_color | reverse_colour |
 | strip_color   | strip_colour   |
+
+---
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,52 @@ This would result in logs in the following format:
 
 `[SystemName CurrentDate CurrentTime CorrelationId PID] Level : -- Message`
 
+#### Prefix Colourisation
+You can colourise the log prefix in several ways:
+
+**Apply colours to the entire prefix:**
+```ruby
+config = DVLA::Herodotus.config do |config|
+  config.prefix_colour = 'blue.bold'
+end
+logger = DVLA::Herodotus.logger('<system-name>', config: config)
+```
+
+**Use an array of colour methods:**
+
+```ruby
+config = DVLA::Herodotus.config do |config|
+  config.prefix_colour = %w[blue bold underline]
+end
+logger = DVLA::Herodotus.logger('<system-name>', config: config)
+```
+
+**Apply different colours to individual components:**
+```ruby
+config = DVLA::Herodotus.config do |config|
+  config.prefix_colour = {
+    system: 'blue.bold',
+    date: 'green',
+    time: 'yellow',
+    correlation: 'magenta',
+    pid: 'cyan',
+    level: 'red.bold',
+    separator: 'white'
+  }
+end
+logger = DVLA::Herodotus.logger('<system-name>', config: config)
+```
+
+The hash keys correspond to different parts of the log prefix:
+- `system`: The system name
+- `date`: The date portion (YYYY-MM-DD)
+- `time`: The time portion (HH:MM:SS)
+- `correlation`: The correlation ID
+- `pid`: The process ID (when display_pid is enabled)
+- `level`: The log level (INFO, WARN, etc.)
+- `separator`: The "-- :" separator
+- `overall`: Applied to the entire prefix after individual components are coloured
+
 ### Syncing logs
 
 Herodotus allows you to Sync correlation_ids between instantiated HerodotusLogger objects. 

--- a/lib/dvla/herodotus.rb
+++ b/lib/dvla/herodotus.rb
@@ -10,7 +10,7 @@ module DVLA
       attr_accessor :main_logger
     end
 
-    CONFIG_ATTRIBUTES = %i[display_pid main].freeze
+    CONFIG_ATTRIBUTES = %i[display_pid main prefix_colour].freeze
 
     def self.config
       config ||= Struct.new(*CONFIG_ATTRIBUTES, keyword_init: true).new
@@ -26,10 +26,10 @@ module DVLA
       if output_path
         if output_path.is_a? String
           output_file = File.open(output_path, 'a')
-          return HerodotusLogger.new(system_name, MultiWriter.new(output_file, $stdout), config: config)
+          return HerodotusLogger.new(system_name, MultiWriter.new(output_file, $stdout, config: config), config: config)
         elsif output_path.is_a? Proc
           proc_writer = ProcWriter.new(output_path)
-          return HerodotusLogger.new(system_name, MultiWriter.new(proc_writer, $stdout), config: config)
+          return HerodotusLogger.new(system_name, MultiWriter.new(proc_writer, $stdout, config: config), config: config)
         else
           raise ArgumentError.new 'Unexpected output_path provided. Expecting either a string or a proc'
         end

--- a/lib/dvla/herodotus.rb
+++ b/lib/dvla/herodotus.rb
@@ -26,10 +26,10 @@ module DVLA
       if output_path
         if output_path.is_a? String
           output_file = File.open(output_path, 'a')
-          return HerodotusLogger.new(system_name, MultiWriter.new(output_file, $stdout, config: config), config: config)
+          return HerodotusLogger.new(system_name, MultiWriter.new(output_file, $stdout), config: config)
         elsif output_path.is_a? Proc
           proc_writer = ProcWriter.new(output_path)
-          return HerodotusLogger.new(system_name, MultiWriter.new(proc_writer, $stdout, config: config), config: config)
+          return HerodotusLogger.new(system_name, MultiWriter.new(proc_writer, $stdout), config: config)
         else
           raise ArgumentError.new 'Unexpected output_path provided. Expecting either a string or a proc'
         end

--- a/lib/dvla/herodotus/herodotus_logger.rb
+++ b/lib/dvla/herodotus/herodotus_logger.rb
@@ -3,7 +3,7 @@ require 'securerandom'
 module DVLA
   module Herodotus
     class HerodotusLogger < Logger
-      attr_accessor :system_name, :correlation_id, :main, :display_pid, :scenario_id
+      attr_accessor :system_name, :correlation_id, :main, :display_pid, :scenario_id, :prefix_colour
 
       # Initializes the logger
       # Sets a default correlation_id and creates the formatter

--- a/lib/dvla/herodotus/herodotus_logger.rb
+++ b/lib/dvla/herodotus/herodotus_logger.rb
@@ -3,7 +3,7 @@ require 'securerandom'
 module DVLA
   module Herodotus
     class HerodotusLogger < Logger
-      attr_accessor :system_name, :correlation_id, :main, :display_pid, :scenario_id, :prefix_colour
+      attr_accessor :system_name, :correlation_id, :main, :display_pid, :scenario_id
 
       # Initializes the logger
       # Sets a default correlation_id and creates the formatter

--- a/lib/dvla/herodotus/herodotus_logger.rb
+++ b/lib/dvla/herodotus/herodotus_logger.rb
@@ -16,6 +16,7 @@ module DVLA
         @main = config[:main]
         @display_pid = config[:display_pid]
         @prefix_colour = config[:prefix_colour]
+        @colour_methods = build_colour_methods(@prefix_colour)
 
         @correlation_id = SecureRandom.uuid[0, 8]
         set_formatter
@@ -70,48 +71,79 @@ module DVLA
       def set_formatter
         self.formatter = proc do |severity, _datetime, _progname, msg|
           now = Time.now
-          system = @system_name
-          date = now.strftime('%Y-%m-%d')
-          time = now.strftime('%H:%M:%S')
-          correlation = @correlation_id
-          pid = @display_pid ? Process.pid.to_s : nil
-          level = severity
-          separator = '-- :'
+          components = {
+            system: @system_name,
+            date: now.strftime('%Y-%m-%d'),
+            time: now.strftime('%H:%M:%S'),
+            correlation: @correlation_id,
+            pid: @display_pid ? Process.pid.to_s : nil,
+            level: severity,
+            separator: '-- :',
+          }
 
-          prefix = case @prefix_colour
-                     # Colourise the whole prefix
-                   when Array, String
-                     bracket_content = [system, date, time, correlation, pid].compact.join(' ')
-                     colourise_text("[#{bracket_content}] #{level} #{separator} ", @prefix_colour)
-                   when Hash
-                     #   Colour each component individually and wrap in an overall colour
-                     s = @prefix_colour[:system] ? colourise_text(system, @prefix_colour[:system]) : system
-                     d = @prefix_colour[:date] ? colourise_text(date, @prefix_colour[:date]) : date
-                     t = @prefix_colour[:time] ? colourise_text(time, @prefix_colour[:time]) : time
-                     c = @prefix_colour[:correlation] ? colourise_text(correlation, @prefix_colour[:correlation]) : correlation
-                     p = pid && @prefix_colour[:pid] ? colourise_text(pid, @prefix_colour[:pid]) : pid
-                     l = @prefix_colour[:level] ? colourise_text(level, @prefix_colour[:level]) : level
-                     sep = @prefix_colour[:separator] ? colourise_text(separator, @prefix_colour[:separator]) : separator
-                     bracket_content = [s, d, t, c, p].compact.join(' ')
-                     result = "[#{bracket_content}] #{l} #{sep} "
-                     @prefix_colour[:overall] ? colourise_text(result, @prefix_colour[:overall]) : result
-                   else
-                     # No colourisation
-                     bracket_content = [system, date, time, correlation, pid].compact.join(' ')
-                     "[#{bracket_content}] #{level} #{separator} "
-                   end
-
+          prefix = apply_prefix_colors(components)
           "#{prefix}#{msg}\n"
         end
       end
 
     private
 
-      def colourise_text(text, colour_spec)
-        return text unless colour_spec
+      VALID_METHODS = %w[
+        white black red green brown yellow blue magenta cyan gray grey
+        bright_red bright_green bright_blue bright_magenta bright_cyan
+        bg_black bg_red bg_green bg_brown bg_yellow bg_blue bg_magenta bg_cyan bg_gray bg_grey bg_white
+        bg_bright_red bg_bright_green bg_bright_blue bg_bright_magenta bg_bright_cyan
+        bold dim italic underline reverse_colour reverse_color
+      ].freeze
 
-        methods = colour_spec.is_a?(Array) ? colour_spec : colour_spec.to_s.split('.')
-        methods.reduce(text) { |str, method| str.public_send(method) }
+      def build_colour_methods(colour_spec)
+        case colour_spec
+        when Array, String
+          methods = colour_spec.is_a?(Array) ? colour_spec : colour_spec.split('.')
+          return {} unless methods.all? { |m| VALID_METHODS.include?(m) }
+
+          { prefix: methods.map(&:to_sym) }
+        when Hash
+          colour_spec.transform_values do |spec|
+            next unless spec
+
+            methods = spec.is_a?(Array) ? spec : spec.split('.')
+            methods.map(&:to_sym) if methods.all? { |m| VALID_METHODS.include?(m) }
+          end.compact
+        else
+          {}
+        end
+      end
+
+      def apply_colors(text, color_methods)
+        return text unless color_methods
+
+        color_methods.reduce(text) { |str, method| str.public_send(method) }
+      end
+
+      def apply_prefix_colors(components)
+        if @colour_methods[:prefix]
+          bracket_content = [components[:system], components[:date], components[:time], 
+                             components[:correlation], components[:pid]].compact.join(' ')
+          text = "[#{bracket_content}] #{components[:level]} #{components[:separator]} "
+          apply_colors(text, @colour_methods[:prefix])
+        elsif @colour_methods.is_a?(Hash) && @colour_methods.any?
+          system = apply_colors(components[:system], @colour_methods[:system])
+          date = apply_colors(components[:date], @colour_methods[:date])
+          time = apply_colors(components[:time], @colour_methods[:time])
+          correlation = apply_colors(components[:correlation], @colour_methods[:correlation])
+          pid = components[:pid] && apply_colors(components[:pid], @colour_methods[:pid])
+          level = apply_colors(components[:level], @colour_methods[:level])
+          separator = apply_colors(components[:separator], @colour_methods[:separator])
+
+          bracket_content = [system, date, time, correlation, pid].compact.join(' ')
+          result = "[#{bracket_content}] #{level} #{separator} "
+          apply_colors(result, @colour_methods[:overall]) || result
+        else
+          bracket_content = [components[:system], components[:date], components[:time], 
+                             components[:correlation], components[:pid]].compact.join(' ')
+          "[#{bracket_content}] #{components[:level]} #{components[:separator]} "
+        end
       end
 
       def set_proc_writer_scenario

--- a/lib/dvla/herodotus/multi_writer.rb
+++ b/lib/dvla/herodotus/multi_writer.rb
@@ -3,8 +3,7 @@ module DVLA
     class MultiWriter
       attr_reader :targets
 
-      def initialize(*targets, config: nil)
-        @config = config
+      def initialize(*targets)
         @targets = *targets
       end
 

--- a/lib/dvla/herodotus/multi_writer.rb
+++ b/lib/dvla/herodotus/multi_writer.rb
@@ -3,7 +3,8 @@ module DVLA
     class MultiWriter
       attr_reader :targets
 
-      def initialize(*targets)
+      def initialize(*targets, config: nil)
+        @config = config
         @targets = *targets
       end
 

--- a/lib/dvla/herodotus/version.rb
+++ b/lib/dvla/herodotus/version.rb
@@ -1,5 +1,5 @@
 module DVLA
   module Herodotus
-    VERSION = '2.2.1'.freeze
+    VERSION = '2.3.0'.freeze
   end
 end


### PR DESCRIPTION
Config block now accepts a hash of styles to apply to the prefix.
Each component can be styled differently and an overall style applied at the end

```
DVLA::Herodotus.config do |c|
  c.prefix_colour = {
    system: %w[blue bold],
    date: %w[green],
    time: %w[yellow],
    correlation: %w[magenta],
    pid: %w[cyan],
    level: %w[red bold],
    separator: %w[white],
    overall: %w[underline],
  }
  ```


<img width="713" height="200" alt="Screenshot 2025-10-06 at 09 59 21" src="https://github.com/user-attachments/assets/94441b4f-07ed-4c6a-8107-450e6776a744" />
