### PR TITLE
Spawn child logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.3.2] - 2025-12-23
+- Add 'spawn_child_logger' method to allow other processes to inherit the current logger's configuration
+
 ## [2.3.1] - 2025-11-21
 - Fixed issue with output_path in create_logger, will now make a directory if it did not exist
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,22 @@ You can call `new_scenario` with the identifier just before each scenario to cre
 logger.new_scenario('Scenario Id')
 ```
 
+### spawn_child_logger method
+You can call `spawn_child_logger` with a new system_name which will retain the current logger's config.
+This enables you to pass loggers to other tools and maintain the same colourisation and output_path.
+
+```ruby
+config = DVLA::Herodotus.config do |configuration|
+  configuration.display_pid = false
+  configuration.main = true
+  configuration.prefix_colour = {
+    overall: %w[blue bold],
+  }
+end
+LOG = DVLA::Herodotus.logger('<system-name>', config:, output_path: -> { "log.txt" })
+NewTool.new(logger: LOG.spawn_child_logger(system_name: 'new gem'))
+```
+
 ---
 ### Strings
 

--- a/lib/dvla/herodotus/herodotus_logger.rb
+++ b/lib/dvla/herodotus/herodotus_logger.rb
@@ -58,6 +58,16 @@ module DVLA
         end
       end
 
+      # Creates a new logger with a different system name but inherits config and output path
+      def spawn_child_logger(system_name:)
+        config = DVLA::Herodotus.config do |c|
+          c.display_pid = @display_pid
+          c.main = false
+          c.prefix_colour = @prefix_colour
+        end
+        HerodotusLogger.new(system_name, @logdev.dev, config: config)
+      end
+
       %i[debug info warn error fatal].each do |log_level|
         define_method log_level do |progname = nil, &block|
           set_proc_writer_scenario

--- a/lib/dvla/herodotus/version.rb
+++ b/lib/dvla/herodotus/version.rb
@@ -1,5 +1,5 @@
 module DVLA
   module Herodotus
-    VERSION = '2.3.1'.freeze
+    VERSION = '2.3.2'.freeze
   end
 end

--- a/spec/dvla/herodotus/herodotus_logger_spec.rb
+++ b/spec/dvla/herodotus/herodotus_logger_spec.rb
@@ -311,8 +311,15 @@ RSpec.describe DVLA::Herodotus::HerodotusLogger do
     end
 
     it 'should share the same output device as parent' do
-      child_logger = logger.spawn_child_logger(system_name: 'child-rspec')
-      expect(child_logger.instance_variable_get(:@logdev).dev).to eq(logger.instance_variable_get(:@logdev).dev)
+      output_device = StringIO.new
+      parent_logger = DVLA::Herodotus::HerodotusLogger.new('parent-rspec', output_device)
+      child_logger = parent_logger.spawn_child_logger(system_name: 'child-rspec')
+
+      parent_logger.info('parent message')
+      child_logger.info('child message')
+
+      expect(output_device.string).to include('parent message')
+      expect(output_device.string).to include('child message')
     end
 
     it 'should inherit prefix_colour from parent when set' do


### PR DESCRIPTION
new method to allow creating new loggers with existing config. This allows us to provide a logger for use by other gems but maintains the existing output_path and prefix colour scheme.


<img width="1206" height="582" alt="Screenshot 2025-12-23 at 10 25 59" src="https://github.com/user-attachments/assets/4bc27b22-d0f7-40d3-b5a4-ebe0b21a1ae2" />
